### PR TITLE
DW-5194: Mirror minio release to artefact bucket

### DIFF
--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -9,3 +9,6 @@ groups:
   - name: pull-request
     jobs:
       - dataworks-aws-tarball-ingester-pr
+  - name: mirror-minio
+    jobs:
+      - mirror-minio

--- a/ci/jobs/mirror-minio.yml
+++ b/ci/jobs/mirror-minio.yml
@@ -1,0 +1,30 @@
+jobs:
+  - name: mirror-minio
+    plan:
+      - get: aws-management-infrastructure
+      - .: (( inject meta.plan.terraform-output ))
+
+      - task: mirror-minio
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: ((dataworks.docker_awscli_repository))
+              version: ((dataworks.docker_awscli_version))
+              tag: ((dataworks.docker_awscli_version))
+          inputs:
+            - name: bucket-name
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+            AWS_DEFAULT_REGION: ((dataworks.aws_region))
+          run:
+            path: sh
+            args:
+              - -exc
+              - |
+                export AWS_DEFAULT_REGION
+                source /assume-role
+                export BUCKET=`cat bucket-name/bucket-name`
+                curl -O https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
+                aws s3 cp minio.RELEASE.* s3://${BUCKET}/minio/

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -88,3 +88,22 @@ meta:
       params:
         DETAILED_EXITCODE: -detailed-exitcode
 
+    terraform-output:
+      task: terraform-output
+      .: (( inject meta.plan.terraform-common-config ))
+      config:
+        params:
+          TF_WORKSPACE: management
+        run:
+          path: sh
+          dir: aws-management-infrastructure
+          args:
+            - -exc
+            - |
+              terraform init
+              terraform workspace show
+              terraform output artefact_bucket | grep "\"id\" = " | awk '{print $3}' | sed 's/"//g' > ../bucket-name/bucket-name
+        inputs:
+          - name: aws-management-infrastructure
+        outputs:
+          - name: bucket-name

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -38,3 +38,16 @@ resources:
         is-public: false
         state: available
         name: dw-al2-hardened-ami-*
+
+  - name: aws-management-infrastructure
+    type: git
+    source:
+      branch: master
+      access_token: ((dataworks-secrets.enterprise_github_pat))
+      v3_endpoint: https://((dataworks.enterprise_github_url))/api/v3/
+      v4_endpoint: https://((dataworks.enterprise_github_url))/api/graphql
+      uri: https://((dataworks.enterprise_github_url))/dip/aws-management-infrastructure.git
+      username: ((dataworks.enterprise_github_username))
+      password: ((dataworks-secrets.enterprise_github_pat))
+    check_every: 5m
+    webhook_token: ((dataworks.concourse_github_webhook_token))


### PR DESCRIPTION
The MinIO download server speed is very temperamental so mirror
the MinIO release to the artefact bucket so our servers start
up in a reasonable amount of time.